### PR TITLE
Default features directory on config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -56,8 +56,9 @@ class Config {
   }
 
   remap(attributes) {
+
     return Object.assign(attributes, {
-      features: attributes.featuresDirectory
+      features: attributes.featuresDirectory || path.resolve(this.base, 'features')
     });
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -56,7 +56,6 @@ class Config {
   }
 
   remap(attributes) {
-
     return Object.assign(attributes, {
       features: attributes.featuresDirectory || path.resolve(this.base, 'features')
     });


### PR DESCRIPTION
I don't think this is the most elegant way of doing it. But, if fixes a bug where if you have a `.cucaroo.config.js` present, but don't define `featuresDirectory` then it will still use the `defaultPaths().feature` location.