### PR TITLE
Run select files, acceptance level tests

### DIFF
--- a/bin/cucaroo
+++ b/bin/cucaroo
@@ -7,4 +7,5 @@ const Runner = require('../lib/suite-runner');
 
 let filters = process.argv.slice(2);
 let config = new Config(process.stdout, filters);
+config.load();
 new Runner(config).run();

--- a/bin/cucaroo
+++ b/bin/cucaroo
@@ -5,6 +5,6 @@
 const Config = require('../lib/config');
 const Runner = require('../lib/suite-runner');
 
-let config = new Config(process.stdout);
-config.load();
+let filters = process.argv.slice(2);
+let config = new Config(process.stdout, filters);
 new Runner(config).run();

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,7 +12,7 @@ class Config {
     this.outputStream = outputStream;
     this.logger = new Config.Logger(outputStream);
     this.base = process.cwd();
-    this.filters = filters;
+    this.filters = filters || [];
   }
 
   load(configPath) {
@@ -26,7 +26,7 @@ class Config {
 
   loadFromConfigFile() {
     this.fileAttributes = {};
-    let message = '`cucaroo.config.js` config file not found. Using default values.'
+    let message = '`.cucaroo.config.js` config file not found. Using default values.'
     this.tryOrWarn(() => {
       this.fileAttributes = this.remap(require(this.configPath));
     }, message);

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,10 +8,11 @@ const loadFeatures = require('./load-features');
 const Logger       = require('./logger');
 
 class Config {
-  constructor(outputStream) {
+  constructor(outputStream, filters) {
     this.outputStream = outputStream;
     this.logger = new Config.Logger(outputStream);
     this.base = process.cwd();
+    this.filters = filters;
   }
 
   load(configPath) {
@@ -35,6 +36,18 @@ class Config {
     this.features = [];
     this.tryOrWarn(() => {
       this.features = loadFeatures(this.paths().features);
+    });
+    if (this.filters.length) {
+      this.filterFeatures();
+    }
+  }
+
+  filterFeatures() {
+    let filters = this.filters.map((path) => {
+      return this.base + '/' + path;
+    });
+    this.features = this.features.filter((feature) => {
+      return filters.includes(feature.filename);
     });
   }
 

--- a/lib/load-features.js
+++ b/lib/load-features.js
@@ -10,7 +10,10 @@ module.exports = function loadFeatures(dirname) {
   function handleFile(basedir, filename, stat) {
     if (path.extname(filename) !== '.feature') { return; }
     let fullPath = path.join(basedir, filename);
-    files.push(fs.readFileSync(fullPath).toString());
+    files.push({
+      content: fs.readFileSync(fullPath).toString(),
+      filename: fullPath
+    });
   }
 
   fsWalk.walkSync(dirname, handleFile);

--- a/lib/suite-observer.js
+++ b/lib/suite-observer.js
@@ -21,6 +21,10 @@ class SuiteObserver {
     };
   }
 
+  exitCode() {
+    return this.data.features.fail;
+  }
+
   handleEvent(event, item, err) {
     let method = event.replace(/-([a-z])/g, (match) => { return match[1].toUpperCase(); });
     this[method] && this[method](item, err);

--- a/lib/suite-runner.js
+++ b/lib/suite-runner.js
@@ -62,7 +62,7 @@ class SuiteRunner {
   }
 
   close() {
-    process.exit(this.observer.data.features.fail);
+    process.exit(this.observer.exitCode());
   }
 }
 

--- a/lib/suite-runner.js
+++ b/lib/suite-runner.js
@@ -40,7 +40,9 @@ class SuiteRunner {
 
   compileFeatures() {
     this.features  = this.rawFeatures.map((feature) => {
-      return SuiteRunner.compile(feature, this.logger);
+      let compiled = SuiteRunner.compile(feature.content, this.logger);
+      compiled.filename = feature.filename;
+      return compiled;
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucaroo",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Light cucumber implementation for node javascript",
   "main": "bin/cucaroo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test:unit": "mocha test/unit --recursive",
-    "test": "npm run test:unit"
+    "test:acceptance": "mocha test/acceptance --recursive",
+    "test": "npm run test:unit && npm run test:acceptance"
   },
   "repository": {
     "type": "git",

--- a/test/acceptance/ambiguous-feature-test.js
+++ b/test/acceptance/ambiguous-feature-test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('assert');
+const OutputStream  = require('../unit/support/output-stream');
+
+const Config        = require('../../lib/config');
+const Runner        = require('../../lib/suite-runner');
+
+describe('failure.feature', function() {
+  let config, runner, mockStream, outputStream, exitCode;
+
+  beforeEach(function() {
+    mockStream    = new OutputStream();
+    outputStream  = mockStream.stream;
+    config        = new Config(outputStream, ['test/features/failure.feature']);
+    config.load();
+  });
+
+  it('returns an error code', function(done) {
+    Runner.prototype.close = function() {
+      assert.equal(this.observer.exitCode(), 1);
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs the feature header', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Feature with a whole lot of errors'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs scenario info', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Scenario: Assertion failure'));
+      assert(plainOutput.includes('Scenario: Runtime errors'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Prints comments about which steps are unimplemented', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('When  And then I make an assertion that aint true  // step threw an error; halting scenario'));
+      assert(plainOutput.includes('When  I make an error resulting in a runtime failure  // step threw an error; halting scenario'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Spits out stacktraces', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('AssertionError: it isnt like we thought'));
+      assert(plainOutput.includes('ReferenceError: failHard is not defined'));
+      assert(plainOutput.includes('at StepValue.implementation'));
+      assert(plainOutput.includes('test/features/step_definitions/failing-steps.js:24:5'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Summarizes correctly', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Some features failed:'));
+      assert(plainOutput.includes('Features -   Passing: 0, Failing: 1'));
+      assert(plainOutput.includes('Scenarios -  Passing: 0, Failing: 2'));
+      assert(plainOutput.includes('Steps -      Passing: 2, Failing: 2'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+});

--- a/test/acceptance/failing-feature-test.js
+++ b/test/acceptance/failing-feature-test.js
@@ -16,7 +16,7 @@ describe('pending.feature', function() {
     config.load();
   });
 
-  it('runs successfully', function(done) {
+  it('returns an error code', function(done) {
     Runner.prototype.close = function() {
       assert.equal(this.observer.exitCode(), 1);
       done();

--- a/test/acceptance/failing-feature-test.js
+++ b/test/acceptance/failing-feature-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('assert');
+const OutputStream  = require('../unit/support/output-stream');
+
+const Config        = require('../../lib/config');
+const Runner        = require('../../lib/suite-runner');
+
+describe('pending.feature', function() {
+  let config, runner, mockStream, outputStream, exitCode;
+
+  beforeEach(function() {
+    mockStream    = new OutputStream();
+    outputStream  = mockStream.stream;
+    config        = new Config(outputStream, ['test/features/pending.feature']);
+    config.load();
+  });
+
+  it('runs successfully', function(done) {
+    Runner.prototype.close = function() {
+      assert.equal(this.observer.exitCode(), 1);
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs the feature header', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Feature with pending steps'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Prints comments about which step is pending', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Given  The first step is pending by throwing a pending error  // step is pending; halting scenario'));
+      assert(plainOutput.includes('Given  The first step is pending by passing a pending error to the callback  // step is pending; halting scenario'));
+      assert(plainOutput.includes('When  I throw in a pending step  // step is pending; halting scenario'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs each scenario info', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Scenario: Pending via thrown error'));
+      assert(plainOutput.includes('Scenario: First step is pending via passing an error to the callback'));
+      assert(plainOutput.includes('Scenario: Later step is pending'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Spits out pending step summary', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Pending steps!!!'));
+      assert(plainOutput.includes('\'The first step is pending by throwing a pending error\''));
+      assert(plainOutput.includes('\'The first step is pending by passing a pending error to the callback\''));
+      assert(plainOutput.includes('\'I throw in a pending step\''));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Summarizes correctly', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Some features failed:'));
+      assert(plainOutput.includes('Features -   Passing: 0, Failing: 1'));
+      assert(plainOutput.includes('Scenarios -  Passing: 0, Failing: 3'));
+      assert(plainOutput.includes('Steps -      Passing: 1, Failing: 0'));
+      assert(plainOutput.includes('Pending: 3'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+});

--- a/test/acceptance/pending-feature-test.js
+++ b/test/acceptance/pending-feature-test.js
@@ -16,7 +16,7 @@ describe('pending.feature', function() {
     config.load();
   });
 
-  it('runs successfully', function(done) {
+  it('returns an error code', function(done) {
     Runner.prototype.close = function() {
       assert.equal(this.observer.exitCode(), 1);
       done();

--- a/test/acceptance/pending-feature-test.js
+++ b/test/acceptance/pending-feature-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('assert');
+const OutputStream  = require('../unit/support/output-stream');
+
+const Config        = require('../../lib/config');
+const Runner        = require('../../lib/suite-runner');
+
+describe('pending.feature', function() {
+  let config, runner, mockStream, outputStream, exitCode;
+
+  beforeEach(function() {
+    mockStream    = new OutputStream();
+    outputStream  = mockStream.stream;
+    config        = new Config(outputStream, ['test/features/pending.feature']);
+    config.load();
+  });
+
+  it('runs successfully', function(done) {
+    Runner.prototype.close = function() {
+      assert.equal(this.observer.exitCode(), 1);
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs the feature header', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Feature with pending steps'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Prints comments about which step is pending', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Given  The first step is pending by throwing a pending error  // step is pending; halting scenario'));
+      assert(plainOutput.includes('Given  The first step is pending by passing a pending error to the callback  // step is pending; halting scenario'));
+      assert(plainOutput.includes('When  I throw in a pending step  // step is pending; halting scenario'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs each scenario info', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Scenario: Pending via thrown error'));
+      assert(plainOutput.includes('Scenario: First step is pending via passing an error to the callback'));
+      assert(plainOutput.includes('Scenario: Later step is pending'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Spits out pending step summary', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Pending steps!!!'));
+      assert(plainOutput.includes('\'The first step is pending by throwing a pending error\''));
+      assert(plainOutput.includes('\'The first step is pending by passing a pending error to the callback\''));
+      assert(plainOutput.includes('\'I throw in a pending step\''));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Summarizes correctly', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Some features failed:'));
+      assert(plainOutput.includes('Features -   Passing: 0, Failing: 1'));
+      assert(plainOutput.includes('Scenarios -  Passing: 0, Failing: 3'));
+      assert(plainOutput.includes('Steps -      Passing: 1, Failing: 0'));
+      assert(plainOutput.includes('Pending: 3'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+});

--- a/test/acceptance/success-feature-test.js
+++ b/test/acceptance/success-feature-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('assert');
+const OutputStream  = require('../unit/support/output-stream');
+
+const Config        = require('../../lib/config');
+const Runner        = require('../../lib/suite-runner');
+
+describe('success.feature', function() {
+  let config, runner, mockStream, outputStream, exitCode;
+
+  beforeEach(function() {
+    mockStream    = new OutputStream();
+    outputStream  = mockStream.stream;
+    config        = new Config(outputStream, ['test/features/success.feature']);
+    config.load();
+  });
+
+  it('runs successfully', function(done) {
+    Runner.prototype.close = function() {
+      assert.equal(this.observer.exitCode(), 0);
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs the feature header', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Feature: Successful feature runs'));
+      assert(plainOutput.includes('As a BDD developer'));
+      assert(plainOutput.includes('I want to implement and run cucumber tests'));
+      assert(plainOutput.includes('So that I have regression testing, and a starting place for talking with product people'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs the scenario information', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Scenario: All is good'));
+      assert(plainOutput.includes('Given  all step definitions are defined'));
+      assert(plainOutput.includes('When  I run the feature'));
+      assert(plainOutput.includes('And  the exit code should be 0'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Spits out a success summary', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('All features passed!'));
+      assert(plainOutput.includes('Features -   Passing: 1, Failing: 0'));
+      assert(plainOutput.includes('Scenarios -  Passing: 1, Failing: 0'));
+      assert(plainOutput.includes('Steps -      Passing: 4, Failing: 0'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+});

--- a/test/acceptance/unimplemented-feature-test.js
+++ b/test/acceptance/unimplemented-feature-test.js
@@ -16,7 +16,7 @@ describe('ambiguous.feature', function() {
     config.load();
   });
 
-  it('runs successfully', function(done) {
+  it('returns an error code', function(done) {
     Runner.prototype.close = function() {
       assert.equal(this.observer.exitCode(), 1);
       done();

--- a/test/acceptance/unimplemented-feature-test.js
+++ b/test/acceptance/unimplemented-feature-test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('assert');
+const OutputStream  = require('../unit/support/output-stream');
+
+const Config        = require('../../lib/config');
+const Runner        = require('../../lib/suite-runner');
+
+describe('ambiguous.feature', function() {
+  let config, runner, mockStream, outputStream, exitCode;
+
+  beforeEach(function() {
+    mockStream    = new OutputStream();
+    outputStream  = mockStream.stream;
+    config        = new Config(outputStream, ['test/features/ambiguous.feature']);
+    config.load();
+  });
+
+  it('runs successfully', function(done) {
+    Runner.prototype.close = function() {
+      assert.equal(this.observer.exitCode(), 1);
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs the feature header', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Feature with ambiguous steps'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Outputs scenario info', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Scenario: There are ambiguous steps'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Prints comments about which step is ambiguous', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('And  there are two steps with the same text  // 2 definitions exist for this step.'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Spits out ambiguous step summary', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Ambiguous step definitions found for these steps:'));
+      assert(plainOutput.includes('\'there are two steps with the same text\''));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+
+  it('Summarizes correctly', function(done) {
+    Runner.prototype.close = function() {
+      let plainOutput = mockStream.cleanOutput();
+      assert(plainOutput.includes('Some features failed:'));
+      assert(plainOutput.includes('Features -   Passing: 0, Failing: 1'));
+      assert(plainOutput.includes('Scenarios -  Passing: 0, Failing: 1'));
+      assert(plainOutput.includes('Steps -      Passing: 0, Failing: 0'));
+      assert(plainOutput.includes('Ambiguous: 1'));
+      done();
+    };
+    runner = new Runner(config);
+    runner.run();
+  });
+});

--- a/test/features/ambiguous.feature
+++ b/test/features/ambiguous.feature
@@ -1,4 +1,4 @@
-Feature: Successful feature runs
+Feature: Feature with ambiguous steps
   As a BDD developer
   I want to be informed about ambigous step definitions
   So that I can keep my test code clean and not run the wrong step

--- a/test/unit/config-test.js
+++ b/test/unit/config-test.js
@@ -13,7 +13,7 @@ describe('Config', function() {
   beforeEach(function() {
     mockStream    = new OutputStream();
     outputStream  = mockStream.stream;
-    config        = new Config(outputStream);
+    config        = new Config(outputStream, []);
   });
 
   it('should create a logger based on the output stream', function() {
@@ -60,12 +60,12 @@ describe('Config', function() {
 
   it('should read all the features on load', function() {
     config.load();
-    assert(config.features.length >= 1);
+    assert(config.features.length >= 5);
   });
 
   it('should require all the step definitions on load', function() {
     config.load();
-    assert(config.stepExports.length >= 1);
+    assert(config.stepExports.length >= 5);
   });
 
   it('requires the setup and teardown scripts', function() {
@@ -74,5 +74,13 @@ describe('Config', function() {
     let teardown = require('../features/support/teardown');
     assert.equal(config.setup, setup);
     assert.equal(config.teardown, teardown);
+  });
+
+  describe('when passed filters', function() {
+    it('when one relative file path is passed, it reduces features to that file', function() {
+      config = new Config(outputStream, ['test/features/success.feature']);
+      config.load();
+      assert.equal(config.features.length, 1);
+    });
   });
 });

--- a/test/unit/config-test.js
+++ b/test/unit/config-test.js
@@ -42,7 +42,7 @@ describe('Config', function() {
 
   it('logs a warning if the config file is not found', function() {
     config.load('not-here.yo');
-    let expectedMessage = '`cucaroo.config.js` config file not found.';
+    let expectedMessage = '`.cucaroo.config.js` config file not found.';
     assert(mockStream.cleanOutput().includes(expectedMessage));
   });
 


### PR DESCRIPTION
This PR does a combo deal: It allows filtering of features my file path, and it uses this ability to write acceptances level tests for the features in the `test/features` directory.

It also adds a script to `package.json` for running acceptance tests and puts that script to work in the `npm test` command.