### PR TITLE
Bug: step callbacks fail when non err passed

### DIFF
--- a/lib/step-runner.js
+++ b/lib/step-runner.js
@@ -42,6 +42,9 @@ class StepRunner {
     } else if (err.message && err.message.toLowerCase() === 'pending') {
       this.step.emit('pending', this.step, err);
     } else {
+      if (!err.message) {
+        err = new Error(`Step callback received unexpected, non-error value: ${err}`);
+      }
       this.step.emit('fail', this.step, err);
     }
     this.step.emit('finished', this.step);

--- a/lib/step-runner.js
+++ b/lib/step-runner.js
@@ -39,7 +39,7 @@ class StepRunner {
       this.step.emit('not-run', this.step);
     } else if (!err) {
       this.step.emit('pass', this.step);
-    } else if (err.message.toLowerCase() === 'pending') {
+    } else if (err.message && err.message.toLowerCase() === 'pending') {
       this.step.emit('pending', this.step, err);
     } else {
       this.step.emit('fail', this.step, err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucaroo",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Light cucumber implementation for node javascript",
   "main": "bin/cucaroo",
   "bin": {

--- a/test/unit/step-runner-test.js
+++ b/test/unit/step-runner-test.js
@@ -116,12 +116,14 @@ describe('StepRunner', function() {
   });
 
   describe('#emit(err)', function() {
-    let events;
+    let events, errs;
 
     beforeEach(function() {
       events = [];
-      stepValue.onAny(function(event) {
+      errs = [];
+      stepValue.onAny(function(event, _step, err) {
         events.push(event);
+        errs.push(err);
       });
     });
 
@@ -140,9 +142,10 @@ describe('StepRunner', function() {
       assert.equal(events[0], 'fail');
     });
 
-    it('when it receives a non-error value, it emits a a \'fail\' on the step', function() {
+    it('when it receives a non-error value, it emits a \'fail\' on the step, and passes along an error about the funky', function() {
       runner.emit('some random string');
       assert.equal(events[0], 'fail');
+      assert.equal(errs[0].message, 'Step callback received unexpected, non-error value: some random string');
     });
   });
 });

--- a/test/unit/step-runner-test.js
+++ b/test/unit/step-runner-test.js
@@ -114,4 +114,35 @@ describe('StepRunner', function() {
       done();
     });
   });
+
+  describe('#emit(err)', function() {
+    let events;
+
+    beforeEach(function() {
+      events = [];
+      stepValue.onAny(function(event) {
+        events.push(event);
+      });
+    });
+
+    it('when there is no error, it emits a \'pass\' on the step', function() {
+      runner.emit();
+      assert.equal(events[0], 'pass');
+    });
+
+    it('when there is a pending error, it emits a \'pending\' on the step', function() {
+      runner.emit(new Error('Pending'));
+      assert.equal(events[0], 'pending');
+    });
+
+    it('when there is a different error, it emits a \'fail\' on the step', function() {
+      runner.emit(new Error('Oh crap!'));
+      assert.equal(events[0], 'fail');
+    });
+
+    it('when it receives a non-error value, it emits a a \'fail\' on the step', function() {
+      runner.emit('some random string');
+      assert.equal(events[0], 'fail');
+    });
+  });
 });


### PR DESCRIPTION
In `mocha`, when anything truthy is passed to the callback done, the tests fails. Right now cucaroo is erroring out because it expects the thing it receives to be nothing or an error. It tries to look at the error message to figure out what to do and then things go wrong in the case of a string or object.

To make matters worse, the libraries `horseman` and `nightmare` have a chaining/promise-like mechanism that passes along unexpected stuff to the next step.

This set of commits fails when it receives these messages, but passes along a real error saying it got the wrong kind of thing in the callback.